### PR TITLE
Add ubuntu.js, ubuntu-releases.js

### DIFF
--- a/lastupdate/canonical.js
+++ b/lastupdate/canonical.js
@@ -1,0 +1,10 @@
+/** Possible Canonical server names */
+const SERVER_NAMES = ["aerodent", "actiontoad", "kazooie", "banjo"];
+module.exports = async function (repoUrl, tracePrefix) {
+  let trace = null;
+  for (const name of SERVER_NAMES) {
+    trace = await fetch(repoUrl + tracePrefix + name);
+    if (trace.status === 200) break;
+  }
+  return Math.round(new Date(await trace.text()) / 1000);
+};

--- a/lastupdate/ubuntu-releases.js
+++ b/lastupdate/ubuntu-releases.js
@@ -1,0 +1,4 @@
+const canonical = require('./canonical');
+module.exports = async function (repoUrl) {
+  return await canonical(repoUrl, '/.trace/releases-')
+};

--- a/lastupdate/ubuntu.js
+++ b/lastupdate/ubuntu.js
@@ -1,0 +1,4 @@
+const canonical = require('./canonical');
+module.exports = async function (repoUrl) {
+  return await canonical(repoUrl, '/.trace/ubuntu-')
+};

--- a/main.js
+++ b/main.js
@@ -100,6 +100,8 @@ const REPO = {
   "mariadb": require("./lastupdate/mariadb"),
   "msys2": require("./lastupdate/msys2"),
   "postgresql": require("./lastupdate/postgresql"),
+  "ubuntu": require("./lastupdate/ubuntu"),
+  "ubuntu-releases": require("./lastupdate/ubuntu-releases"),
 };
 
 const {InfluxDB, Point, HttpError} = require('@influxdata/influxdb-client')


### PR DESCRIPTION
Canonical Ltd. has multiple servers for serving Ubuntu sources. Path of trace files varies from each of these machines. e.g. For server `aerodent`, the trace files is `/.traces/ubuntu-aerodent`. Currently Canonical seems to serve Ubuntu files on these machines

```
aerodent
actiontoad
kazooie
banjo
```